### PR TITLE
Filter JES based on App2App communication

### DIFF
--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -61,17 +61,18 @@ export class Filters extends React.Component {
             const data = event.data;
             if (data && data.dispatchType && data.dispatchData) {
                 switch (data.dispatchType) {
-                case 'launch':            
-                case 'message':
-                    const messageData = data.dispatchType === 'launch'
-                        ? data.dispatchData.launchMetadata.data
-                        : data.dispatchData.data;
-                    if (messageData.owner && messageData.prefix) {
-                        dispatch(setFilters(messageData));
-                        dispatch(fetchJobs(messageData));
-                    }
-                default:
-                    console.warn(`Unknown app2app type=${data.dispatchType}`);
+                    case 'launch':
+                    case 'message':
+                        const messageData = data.dispatchType === 'launch'
+                            ? data.dispatchData.launchMetadata.data
+                            : data.dispatchData.data;
+                        if (messageData.owner && messageData.prefix) {
+                            dispatch(setFilters(messageData));
+                            dispatch(fetchJobs(messageData));
+                        }
+                        break;
+                    default:
+                        console.warn(`Unknown app2app type=${data.dispatchType}`);
                 }
             }
         }

--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -56,6 +56,26 @@ export class Filters extends React.Component {
             dispatch(setFilters(queryFilters));
             dispatch(fetchJobs(queryFilters));
         }
+
+        function receiveMessage(event) {
+            const data = event.data;
+            if (data && data.dispatchType && data.dispatchData) {
+                switch (data.dispatchType) {
+                case 'launch':            
+                case 'message':
+                    const messageData = data.dispatchType === 'launch'
+                        ? data.dispatchData.launchMetadata.data
+                        : data.dispatchData.data;
+                    if (messageData.owner && messageData.prefix) {
+                        dispatch(setFilters(messageData));
+                        dispatch(fetchJobs(messageData));
+                    }
+                default:
+                    console.warn(`Unknown app2app type=${data.dispatchType}`);
+                }
+            }
+        }
+        window.addEventListener('message', e => { receiveMessage(e); }, false);
     }
 
     componentDidMount() {

--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -62,7 +62,7 @@ export class Filters extends React.Component {
             if (data && data.dispatchType && data.dispatchData) {
                 switch (data.dispatchType) {
                     case 'launch':
-                    case 'message':
+                    case 'message': {
                         const messageData = data.dispatchType === 'launch'
                             ? data.dispatchData.launchMetadata.data
                             : data.dispatchData.data;
@@ -71,6 +71,7 @@ export class Filters extends React.Component {
                             dispatch(fetchJobs(messageData));
                         }
                         break;
+                    }
                     default:
                         console.warn(`Unknown app2app type=${data.dispatchType}`);
                 }

--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -66,7 +66,7 @@ export class Filters extends React.Component {
                         const messageData = data.dispatchType === 'launch'
                             ? data.dispatchData.launchMetadata.data
                             : data.dispatchData.data;
-                        if (messageData.owner && messageData.prefix) {
+                        if (messageData.owner && messageData.jobId) {
                             dispatch(setFilters(messageData));
                             dispatch(fetchJobs(messageData));
                         }
@@ -78,6 +78,7 @@ export class Filters extends React.Component {
             }
         }
         window.addEventListener('message', e => { receiveMessage(e); }, false);
+        window.top.postMessage('iframeload', '*');
     }
 
     componentDidMount() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-jes",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-jes",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-jes",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "dependencies": {
     "babel-polyfill": "^6.16.0",
     "file-loader": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-jes",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "dependencies": {
     "babel-polyfill": "^6.16.0",
     "file-loader": "^0.11.2",

--- a/tests/actions/TestFilters.js
+++ b/tests/actions/TestFilters.js
@@ -13,6 +13,9 @@ import expect from 'expect';
 import { shallow } from 'enzyme';
 import { Filters } from '../../WebContent/js/containers/Filters';
 
+//window really exists at runtime, but the tests don't know this, so we mock it here for app2app use downstream
+global.window = {};
+global.window.addEventListener = () => {};
 
 function setUpOwnerAndPrefix(owner, prefix) {
     const props = {

--- a/tests/actions/TestFilters.js
+++ b/tests/actions/TestFilters.js
@@ -16,6 +16,8 @@ import { Filters } from '../../WebContent/js/containers/Filters';
 // window really exists at runtime, but the tests don't know this, so we mock it here for app2app use downstream
 global.window = {};
 global.window.addEventListener = () => {};
+global.window.top = {};
+global.window.top.postMessage = () => {};
 
 function setUpOwnerAndPrefix(owner, prefix) {
     const props = {

--- a/tests/actions/TestFilters.js
+++ b/tests/actions/TestFilters.js
@@ -13,7 +13,7 @@ import expect from 'expect';
 import { shallow } from 'enzyme';
 import { Filters } from '../../WebContent/js/containers/Filters';
 
-//window really exists at runtime, but the tests don't know this, so we mock it here for app2app use downstream
+// window really exists at runtime, but the tests don't know this, so we mock it here for app2app use downstream
 global.window = {};
 global.window.addEventListener = () => {};
 


### PR DESCRIPTION
Adding prototype of app2app communication listening subject to change in structure with app2app improvements for iframes

Q: How does this work?
A: iframes can now be sent messages through https://github.com/zowe/zlux-app-manager/pull/107 and https://github.com/zowe/zlux-platform/pull/24 ... so it's just up to the iframe apps to listen & react however the developer wants.

The prototype structure is currently
`event.data.dispatchType` determines which type of message, and `event.data.dispatchData` contains a structure dependent upon the type. Maybe dispatchData doesn't exist for certain types yet to be implemented.

I believe this should be completely harmless for the as-is case that nothing is actually sending messages to the explorer, so putting this PR out for future use.

Thanks to @jordanCain for helping guide to the right file to place this code & test stuff out.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>