### PR TITLE
Easier zlux dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ WebContent/app.min.js
 *.war
 bin
 dist
+web
 .scannerwork
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 The issues for the JES explorer are tracked under the Zowe Zlux repository, https://github.com/zowe/zlux and tagged accordingly with the 'explorer-jes' label. Open issues tagged with 'explorer-jes' can be found [here](https://github.com/zowe/zlux/issues?q=is%3Aopen+is%3Aissue+label%3Aexplorer-jes).
 
-## Build 
+# Artifactory Login
+
+This is required for explorer-ui-server and orion editor component
+
+```
+npm config set registry https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release
+npm login
+<Enter artifactory credentials>
+```
+
+# App Development Workflow 
 
 ### Install Dependencies
 
@@ -57,3 +67,35 @@ sonar.login=<hash>
 Then you can run `sonar-scanner` to start code analysis.
 
 Build pipeline has embedded the SonarQube code analysis stage.
+
+
+# ZLUX App Development Workflow
+
+
+## Download:
+
+```
+cd /path/to/zlux
+git clone https://github.com/zowe/explorer-jes.git
+cd explorer-jes
+npm install
+npm run build
+```
+
+## Registering Plugin with Zowe Desktop 
+### Add Plugin Locator
+Add file `org.zowe.explorer-jes.json` to `/path/to/zlux-app-server/plugins`
+
+```
+{
+    "identifier": "org.zowe.explorer-jes",
+    "pluginLocation": "../../explorer-jes"
+}
+```
+
+### Ant Deploy:
+
+```
+cd /path/to/zlux-build
+ant deploy
+```

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "testWatch": "mocha --watch --require babel-core/register tests --recursive",
     "test": "JUNIT_REPORT_PATH=target/report.xml nyc mocha --require babel-core/register tests --recursive --colors --reporter mocha-jenkins-reporter",
     "prod": "cross-env NODE_ENV='production' webpack && cp -r ./WebContent/css ./dist/ && cp -r ./WebContent/img ./dist/ && cp ./WebContent/index.html ./dist/ && cp ./WebContent/favicon.ico ./dist/",
-    "build": "cross-env NODE_ENV='production' webpack && cp -r ./WebContent/css ./web/ && cp -r ./WebContent/img ./web/images && cp ./WebContent/index.html ./web/ && cp ./WebContent/favicon.ico ./web/",
+    "build": "cross-env NODE_ENV='production' webpack --config webpack.config.iframe.js && cp -r ./WebContent/css ./web/ && cp -r ./WebContent/img ./web/images && cp ./WebContent/index.html ./web/ && cp ./WebContent/favicon.ico ./web/",
     "preCommit": "npm-run-all --aggregate-output --parallel --print-label lint test prod"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -65,10 +65,12 @@
   },
   "scripts": {
     "dev": "webpack-dev-server --content-base WebContent --inline --hot",
+    "start": "npm run dev",
     "lint": "eslint ./WebContent/js/ ./tests/",
     "testWatch": "mocha --watch --require babel-core/register tests --recursive",
     "test": "JUNIT_REPORT_PATH=target/report.xml nyc mocha --require babel-core/register tests --recursive --colors --reporter mocha-jenkins-reporter",
     "prod": "cross-env NODE_ENV='production' webpack && cp -r ./WebContent/css ./dist/ && cp -r ./WebContent/img ./dist/ && cp ./WebContent/index.html ./dist/ && cp ./WebContent/favicon.ico ./dist/",
+    "build": "cross-env NODE_ENV='production' webpack && cp -r ./WebContent/css ./web/ && cp -r ./WebContent/img ./web/images && cp ./WebContent/index.html ./web/ && cp ./WebContent/favicon.ico ./web/",
     "preCommit": "npm-run-all --aggregate-output --parallel --print-label lint test prod"
   },
   "nyc": {
@@ -100,6 +102,7 @@
   "author": "IBM",
   "license": "EPL-2.0",
   "config": {
+    "pluginShortName": "JES",
     "pluginId": "org.zowe.explorer-jes",
     "pluginName": "JES Explorer",
     "baseuri": "/ui/v1/explorer-jes"

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -1,0 +1,22 @@
+{
+  "identifier": "org.zowe.explorer-jes",
+  "apiVersion": "1.0.0",
+  "pluginVersion": "1.0.0",
+  "pluginType": "application",
+  "webContent": {
+    "framework": "iframe",
+    "startingPage": "index.html",
+    "launchDefinition": {
+      "pluginShortNameKey": "JES Explorer",
+      "pluginShortNameDefault": "JES Explorer", 
+      "imageSrc": "images/explorer-JES.png"
+    },
+    "descriptionKey": "",
+    "descriptionDefault": "",
+    "isSingleWindowApp": true,
+    "defaultWindowStyle": {
+      "width": 1400,
+      "height": 800
+    }
+  }
+}

--- a/webpack.config.iframe.js
+++ b/webpack.config.iframe.js
@@ -1,0 +1,62 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2018, 2019
+ */
+
+const debug = process.env.NODE_ENV !== 'production';
+const webpack = require('webpack');
+const path = require('path');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+
+module.exports = {
+    devtool: debug ? 'inline-sourcemap' : false,
+    entry: path.join(__dirname, 'WebContent/js/index.js'),
+    module: {
+        rules: [
+            {
+                test: /\.jsx?$/,
+                loader: 'babel-loader',
+                include: [
+                    path.join(__dirname, 'WebContent'),
+                    path.join(__dirname, 'tests'),
+                ],
+                query: {
+                    presets: ['react', 'es2015', 'stage-0'],
+                    plugins: ['react-html-attrs', 'transform-class-properties', 'transform-decorators-legacy'],
+                },
+            },
+            {
+                test: /\.(png|jpg|svg)$/,
+                loader: 'url-loader?limit=1&name=img/[name].[ext]',
+            },
+            {
+                test: /\.css$/,
+                loader: 'style-loader!css-loader',
+            },
+        ],
+    },
+    output: {
+        path: path.join(__dirname, 'web'),
+        filename: 'app.min.js',
+    },
+    plugins: debug ? [] : [
+        new webpack.DefinePlugin({
+            'process.env.REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD': true,
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        }),
+        new UglifyJsPlugin({
+            sourceMap: true,
+            uglifyOptions: {
+                ecma: 8,
+                compress: {
+                    warnings: false,
+                },
+            },
+        }),
+    ],
+};


### PR DESCRIPTION
Added 
- `pluginDefinition.json`, 
- new `build` script in `package.json`, and 
- new `webpack.config.iframe.js` file which has only one difference, instead of `dist` it output build in `web` folder

Will move below steps to readme

Follow  steps to verify:
Download:
```
cd /path/to/zlux
git clone --single-branch --branch easier-zlux-dev-workflow https://github.com/zowe/explorer-jes.git
cd explorer-jes
npm install
npm run build
```

Plugin Locator: add file `org.zowe.explorer-jes.json` to `/path/to/zlux-app-server/plugins` 
```
{
    "identifier": "org.zowe.explorer-jes",
    "pluginLocation": "../../explorer-jes"
}
```
Ant Deploy:
```
cd /path/to/zlux-build
ant deploy
```