### PR TITLE
Fix issue #265 -Job status field missing white space between id and status

### DIFF
--- a/WebContent/js/components/JobInstance.js
+++ b/WebContent/js/components/JobInstance.js
@@ -104,7 +104,7 @@ class JobInstance extends React.Component {
             }
             return (<div style={statusStyleActive}> [{job.get('returnCode')}]</div>);
         } else if (job.get('status')) {
-            return <div style={statusStyleActive}>[{job.get('status')}]</div>;
+            return <div style={statusStyleActive}> [{job.get('status')}]</div>;
         }
         return null;
     }


### PR DESCRIPTION
Add one white space between id and status of job in line 107 of file WebContent\js\components\JobInstance.js