### PR TITLE
Update page title when viewing output files in full screen

### DIFF
--- a/WebContent/js/actions/content.js
+++ b/WebContent/js/actions/content.js
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Copyright IBM Corporation 2016, 2019
+ * Copyright IBM Corporation 2016, 2020
  */
 
 import { atlasFetch } from '../utilities/urlUtils';
@@ -66,9 +66,9 @@ function checkResponse(response) {
     return response.json().then(e => { throw Error(e.message); });
 }
 
-function dispatchReceiveContent(dispatch, jobName, jobId, fileName, fileId, fileLabel, json) {
+function dispatchReceiveContent(dispatch, jobName, jobId, fileName, fileId, fileLabel, json, readOnly = true) {
     if ('content' in json) {
-        return dispatch(receiveContent(jobName, jobId, fileName, fileId, json.content, fileLabel));
+        return dispatch(receiveContent(jobName, jobId, fileName, fileId, json.content, fileLabel, readOnly));
     }
     throw Error(json.message || NO_CONTENT_IN_RESPONSE_ERROR_MESSAGE);
 }
@@ -142,7 +142,7 @@ export function fetchJobFileNoName(jobName, jobId, fileId) {
                         .then(
                             fileName => {
                                 if (fileName) {
-                                    return dispatch(receiveContent(jobName, jobId, fileName, fileId, json.content, getFileLabel(jobId, fileName)));
+                                    return dispatchReceiveContent(dispatch, jobName, jobId, fileName, fileId, getFileLabel(jobId, fileName), json);
                                 }
                                 throw Error(fileName);
                             },
@@ -189,7 +189,7 @@ export function getJCL(jobName, jobId) {
                 return checkResponse(response);
             })
             .then(json => {
-                return dispatch(receiveContent(jobName, jobId, 'JCL', 0, json.content, fileLabel, false));
+                return dispatchReceiveContent(dispatch, jobName, jobId, 'JCL', 0, fileLabel, json, false);
             })
             .catch(e => {
                 dispatch(constructAndPushMessage(`${e.message} - ${jobName}:${jobId}:JCL`));

--- a/WebContent/js/containers/pages/FullScreen.js
+++ b/WebContent/js/containers/pages/FullScreen.js
@@ -25,13 +25,11 @@ class FullScreenViewer extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { title } = this.props;
+        const { title } = this.props; // title from content state
 
-        // Set HTML title if it was changed
+        // Update HTML title if it was changed
         if (prevProps.title !== this.props.title) {
-            if (document.title !== title) {
-                document.title = title;
-            }
+            document.title = title;
         }
     }
 

--- a/WebContent/js/containers/pages/FullScreen.js
+++ b/WebContent/js/containers/pages/FullScreen.js
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Copyright IBM Corporation 2016, 2019
+ * Copyright IBM Corporation 2016, 2020
  */
 
 import React from 'react';
@@ -21,6 +21,17 @@ class FullScreenViewer extends React.Component {
         const { dispatch, validated } = this.props;
         if (!validated) {
             dispatch(validateUser());
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        const { title } = this.props;
+
+        // Set HTML title if it was changed
+        if (prevProps.title !== this.props.title) {
+            if (document.title !== title) {
+                document.title = title;
+            }
         }
     }
 
@@ -50,13 +61,16 @@ FullScreenViewer.propTypes = {
     location: PropTypes.shape({
         search: PropTypes.string,
     }),
+    title: PropTypes.string.isRequired,
 };
 
 function mapStateToProps(state) {
     const validationRoot = state.get('validation');
+    const contentRoot = state.get('content');
     return {
         validated: validationRoot.get('validated'),
         isValidating: validationRoot.get('isValidating'),
+        title: contentRoot.get('title'),
     };
 }
 

--- a/WebContent/js/reducers/content.js
+++ b/WebContent/js/reducers/content.js
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Copyright IBM Corporation 2016, 2019
+ * Copyright IBM Corporation 2016, 2020
  */
 
 import { Map, List } from 'immutable';
@@ -21,10 +21,13 @@ import {
     INVALIDATE_CONTENT,
 } from '../actions/content';
 
+export const DEFAULT_TITLE = 'JES Explorer';
+
 const INITIAL_CONTENT_STATE = Map({
     content: List(),
     selectedContent: 0, // Index of the current active tab content
     isSubmittingJCL: false,
+    title: DEFAULT_TITLE,
 });
 
 function getIndexOfContentFromLabel(contentList, label) {
@@ -46,6 +49,7 @@ export default function content(state = INITIAL_CONTENT_STATE, action) {
             });
         case RECEIVE_CONTENT:
             return state.merge({
+                title: `${DEFAULT_TITLE} [${action.fileLabel}]`,
                 content: state.get('content').set(getIndexOfContentFromLabel(state.get('content'), action.fileLabel),
                     {
                         label: action.fileLabel,
@@ -56,6 +60,7 @@ export default function content(state = INITIAL_CONTENT_STATE, action) {
             });
         case REMOVE_CONTENT:
             return state.merge({
+                title: `${DEFAULT_TITLE}`,
                 content: state.get('content').delete(action.index),
             });
         case UPDATE_CONTENT:

--- a/tests/testResources/reducers/content.js
+++ b/tests/testResources/reducers/content.js
@@ -5,16 +5,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Copyright IBM Corporation 2018, 2019
+ * Copyright IBM Corporation 2018, 2020
  */
 
 import { Map, List } from 'immutable';
+import { DEFAULT_TITLE } from '../../../WebContent/js/reducers/content';
 
 export const baseContent =
     Map({
         content: List(),
         selectedContent: 0,
         isSubmittingJCL: false,
+        title: DEFAULT_TITLE,
     });
 
 export const jobName = 'DEMOJOB';
@@ -27,6 +29,7 @@ export const requestedContent =
         content: List([{ label: `${jobId}-${fileLabel}`, content: '', isFetching: true }]),
         selectedContent: 0,
         isSubmittingJCL: false,
+        title: `${DEFAULT_TITLE}`,
     });
 
 
@@ -35,6 +38,7 @@ export const receivedContent =
         content: List([{ label: fileLabel, content: 'test', isFetching: false, readOnly: true }]),
         selectedContent: 0,
         isSubmittingJCL: false,
+        title: `${DEFAULT_TITLE} [${fileLabel}]`,
     });
 
 export const updatedContent = 'new updated Content';
@@ -43,6 +47,7 @@ export const receivedContentUpdated =
         content: List([{ label: fileLabel, content: updatedContent, isFetching: false, readOnly: true }]),
         selectedContent: 0,
         isSubmittingJCL: false,
+        title: `${DEFAULT_TITLE} [${fileLabel}]`,
     });
 
 
@@ -54,6 +59,7 @@ export const requestedContentWithExistingContent =
         ]),
         selectedContent: 0,
         isSubmittingJCL: false,
+        title: `${DEFAULT_TITLE} [${fileLabel}]`,
     });
 
 export const receivedContent2 =
@@ -64,6 +70,7 @@ export const receivedContent2 =
         ]),
         selectedContent: 0,
         isSubmittingJCL: false,
+        title: `${DEFAULT_TITLE} [${fileLabel2}]`,
     });
 
 export const requestSubmitJCLContent =
@@ -71,4 +78,5 @@ export const requestSubmitJCLContent =
         content: List(),
         selectedContent: 0,
         isSubmittingJCL: true,
+        title: `${DEFAULT_TITLE}`,
     });


### PR DESCRIPTION
In my previous PR, I was updating the title even when not on fullscreen. Now it only updates the title on full screen and for this handling `receive content` was enough. Also I thought it was unnecessary to create a whole new files for window title since it is related to content directly.

I also refactored receiveContent dispatches to dispatchReceiveContent, as @jordanCain requested.