### PR TITLE
move copy inside webpack, new redux logger config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
         "jsx-a11y/no-static-element-interactions":0,
         "lines-between-class-members": ["error", "always"],
         "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/fvtTest/**/*.*", "**/tests/**/*.*"]}]
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/fvtTest/**/*.*", "**/tests/**/*.*", "webpack.*"]}]
     },
     "env": {
         "browser": true,

--- a/README.md
+++ b/README.md
@@ -118,12 +118,29 @@ cd zlux/zlux-app-server/bin
 
 
 ## Enable Redux logs
-Either use Redux Tool Browser Extension in your browser or enable redux logs by setting `enableReduxLogger` variable `true` in your local storage.
+Either use [Redux Dev Tool Browser Extension](https://github.com/reduxjs/redux-devtools) in your browser 
+Or enable redux logs by setting `enableReduxLogger` variable `true` in your local storage.
 
-Run this in browser console
+### Add Redux Logger
+While explore app is open in browser:
+1. Run this in browser console 
 ```
 window.localStorage.setItem('enableReduxLogger', true);
 ```
+
+2. And refresh browser    
+So as long as this value remains true in browser local storage,       
+you will see redux logs in console.                  
+
+### Remove Redux Logger          
+While explore app is open in browser:      
+1. Run either `window.localStorage.setItem('enableReduxLogger', false)`         
+or `window.localStorage.removeItem('enableReduxLogger')`           
+or clear storage manually in `browser dev tools` under `Application` tab 
+
+2. And refresh browser to stop seeing redux console logs.       
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -117,4 +117,15 @@ cd zlux/zlux-app-server/bin
 `explorer-jes` root already have sample `pluginDefinition.json` & will have `web` folder after `build`.
 
 
+## Enable Redux logs
+Either use Redux Tool Browser Extension in your browser or enable redux logs by setting `enableReduxLogger` variable `true` in your local storage.
+
+Run this in browser console
+```
+window.localStorage.setItem('enableReduxLogger', true);
+```
+
+
+
+
 

--- a/WebContent/js/components/dialogs/LoginDialog.js
+++ b/WebContent/js/components/dialogs/LoginDialog.js
@@ -87,7 +87,7 @@ class LoginDialog extends React.Component {
 
         const dialogTitle = !isValidating ?
             (
-                <DialogTitle style={{ 'text-align': 'center' }}>
+                <DialogTitle style={{ textAlign: 'center' }}>
                     <img
                         style={{ width: '100px', display: 'block', marginLeft: 'auto', marginRight: 'auto' }}
                         src={ZoweIcon}

--- a/WebContent/js/index.js
+++ b/WebContent/js/index.js
@@ -24,13 +24,17 @@ import rootReducer from './reducers';
 import JobsView from './containers/pages/Jobs';
 import FullScreenView from './containers/pages/FullScreen';
 
-// uncomment to enable redux dev tool in development
-const store = applyMiddleware(thunk, createLogger())(createStore)(rootReducer, Map({}),
-    //  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
-);
+// redux dev tool extension enabled
+let appMiddleware;
+if (window.localStorage.getItem('enableReduxLogger')) {
+    appMiddleware = applyMiddleware(thunk, createLogger());
+} else {
+    appMiddleware = applyMiddleware(thunk);
+}
 
-// TODO: Need webpack changes to disable console log state changes
-// const store = createStore(rootReducer, Map({}), applyMiddleware(thunk));
+const store = appMiddleware(createStore)(rootReducer, Map({}),
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+);
 
 const theme = createMuiTheme({
     overrides: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,11 +265,34 @@
         }
       }
     },
+    "@types/anymatch": {
+      "version": "1.3.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/anymatch/-/anymatch-1.3.1.tgz",
+      "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.9",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/chai/-/chai-4.2.9.tgz",
       "integrity": "sha1-GUMyYl7SrpFK7wC41co7d+eSTMY=",
       "dev": true
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
     },
     "@types/jss": {
       "version": "9.5.8",
@@ -279,6 +302,12 @@
         "csstype": "^2.0.0",
         "indefinite-observable": "^1.0.1"
       }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+      "dev": true
     },
     "@types/mocha": {
       "version": "7.0.1",
@@ -319,6 +348,76 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/selenium-webdriver/-/selenium-webdriver-4.0.8.tgz",
       "integrity": "sha1-h6KKQxl5A7or2Nr6kYUHYFgkh7g=",
       "dev": true
+    },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
+      "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/tapable/-/tapable-1.0.5.tgz",
+      "integrity": "sha1-mtvBKVBYKqZerXa//fOf4MJ6PAI=",
+      "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.9.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/uglify-js/-/uglify-js-3.9.2.tgz",
+      "integrity": "sha1-AZkled67pnTh41nNa8saHQqy4Cs=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.13",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/webpack/-/webpack-4.41.13.tgz",
+      "integrity": "sha1-mI0RTIkT0Dm4oOBQKn/k8fhPPV4=",
+      "dev": true,
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "0.1.7",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/webpack-sources/-/webpack-sources-0.1.7.tgz",
+      "integrity": "sha1-CjMKlFYRNBDHSl1kGArwy8oAcUE=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -596,6 +695,14 @@
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "assert": {
@@ -1799,9 +1906,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "version": "5.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha1-yWhpAtPJoncp9DqxD515wgBNp7A=",
       "dev": true
     },
     "body-parser": {
@@ -1951,21 +2058,50 @@
       "requires": {
         "bn.js": "^4.1.0",
         "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-sign/-/browserify-sign-4.2.0.tgz",
+      "integrity": "sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
       }
     },
     "browserify-zlib": {
@@ -2286,6 +2422,78 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4="
     },
+    "clean-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha1-qZ2Ow0wcYopFQVZ6p7RXRGRgxis=",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4.4.31",
+        "del": "^4.1.1"
+      },
+      "dependencies": {
+        "del": {
+          "version": "4.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/del/-/del-4.1.1.tgz",
+          "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "globby": "^6.1.0",
+            "is-path-cwd": "^2.0.0",
+            "is-path-in-cwd": "^2.0.0",
+            "p-map": "^2.0.0",
+            "pify": "^4.0.1",
+            "rimraf": "^2.6.3"
+          }
+        },
+        "is-path-cwd": {
+          "version": "2.2.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+          "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+          "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "^2.1.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -2424,6 +2632,19 @@
         "vary": "~1.1.2"
       }
     },
+    "compression-webpack-plugin": {
+      "version": "1.1.12",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/compression-webpack-plugin/-/compression-webpack-plugin-1.1.12.tgz",
+      "integrity": "sha1-vs0q7GIKzpa7P+mkKlXPSKzItNQ=",
+      "dev": true,
+      "requires": {
+        "cacache": "^10.0.1",
+        "find-cache-dir": "^1.0.0",
+        "neo-async": "^2.5.0",
+        "serialize-javascript": "^1.4.0",
+        "webpack-sources": "^1.0.1"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/concat-map/-/concat-map-0.0.1.tgz",
@@ -2533,6 +2754,38 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-webpack-plugin": {
+      "version": "4.6.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
+      "integrity": "sha1-5/QN2KaEd9QF3Rt6hUquMksVi64=",
+      "dev": true,
+      "requires": {
+        "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.0",
+        "loader-utils": "^1.1.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^1.0.0",
+        "serialize-javascript": "^1.4.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        }
+      }
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/core-js/-/core-js-1.2.7.tgz",
@@ -2583,6 +2836,14 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "create-error-class": {
@@ -2972,6 +3233,34 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
+      "dev": true,
+      "requires": {
+        "path-type": "^3.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        }
       }
     },
     "dns-equal": {
@@ -3083,6 +3372,14 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {
@@ -3716,34 +4013,6 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "expand-brackets": {
@@ -4945,12 +5214,6 @@
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-value/-/get-value-2.0.6.tgz",
@@ -5135,13 +5398,33 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
       }
     },
     "hash.js": {
@@ -5915,7 +6198,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "1.7.3",
-          "resolved": "https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/node-fetch/-/node-fetch-1.7.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-fetch/-/node-fetch-1.7.3.tgz",
           "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
           "requires": {
             "encoding": "^0.1.11",
@@ -6562,15 +6845,6 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -6752,6 +7026,14 @@
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "mime": {
@@ -7839,17 +8121,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -8041,6 +8312,13 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
+      "dev": true,
+      "optional": true
     },
     "pidtree": {
       "version": "0.3.0",
@@ -8316,6 +8594,14 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "pump": {
@@ -10604,14 +10890,136 @@
       }
     },
     "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
+      "version": "1.7.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-1.7.2.tgz",
+      "integrity": "sha1-wC5NTUmRPD5+EiwzJTZa+dMx6ao=",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^3.4.0",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha1-swYRQjzjdjV8dlubj5BLn7o8C+g=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+          "dev": true,
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha1-mUihhmy71suCTeoTp+1pH2yN3/A=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
       }
     },
     "wbuf": {
@@ -10654,9 +11062,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.11.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.11.0.tgz",
-          "integrity": "sha1-w2B8vIrjktilpTbyWyH45fP4f+k=",
+          "version": "6.12.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -10688,6 +11096,32 @@
             "wordwrap": "0.0.2"
           }
         },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
         "fast-deep-equal": {
           "version": "3.1.1",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -10698,6 +11132,12 @@
           "version": "1.0.3",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-caller-file/-/get-caller-file-1.0.3.tgz",
           "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "has-flag": {
@@ -10726,6 +11166,26 @@
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
         },
         "require-main-filename": {
           "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "babel-register": "^6.14.0",
     "chai": "^4.2.0",
     "chai-things": "0.2.0",
+    "clean-webpack-plugin": "^3.0.0",
+    "compression-webpack-plugin": "^1.1.12",
+    "copy-webpack-plugin": "^4.5.2",
     "cross-env": "^5.0.0",
     "css-loader": "^1.0.1",
     "dotenv": "^6.2.0",
@@ -84,10 +87,8 @@
     "testWatch": "mocha --watch --require babel-core/register tests/UnitTests --recursive",
     "test": "cross-env JUNIT_REPORT_PATH=target/report.xml nyc mocha --require babel-core/register tests/UnitTests --recursive --colors --reporter mocha-jenkins-reporter",
     "test:fvt": "cross-env JUNIT_REPORT_PATH=target/report-fvt.xml mocha --timeout 999999 --require ts-node/register tests/FVTTests/**/*.ts --recursive --colors --reporter mocha-jenkins-reporter",
-    "prod": "cross-env NODE_ENV='production' webpack && cp -r ./WebContent/zlux-hooks ./dist/ && cp -r ./WebContent/css ./dist/ && cp -r ./WebContent/img ./dist/ && cp ./WebContent/index.html ./dist/ && cp ./WebContent/favicon.ico ./dist/",
-    "build": "npm run clean && cross-env NODE_ENV='development' OUTPUT_FOLDER='web' webpack --progress --colors && npm run copy-static",
-    "copy-static": "cp ./WebContent/index.html ./web/ && cp ./WebContent/favicon.ico ./web/ && cp -r ./WebContent/css ./web/css && cp -r ./WebContent/img ./web/images && cp -r ./WebContent/zlux-hooks ./web/zlux-hooks",
-    "clean": "rimraf web",
+    "prod": "cross-env NODE_ENV='production' webpack",
+    "build": "cross-env NODE_ENV='development' OUTPUT_FOLDER='web' webpack --progress --colors",
     "preCommit": "npm-run-all --aggregate-output --parallel --print-label lint test prod"
   },
   "nyc": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,33 @@ const OUTPUT_FOLDER = process.env.OUTPUT_FOLDER || 'dist';
 const webpack = require('webpack');
 const path = require('path');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const CompressionPlugin = require('compression-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
+const copyTask = new CopyWebpackPlugin([{
+    from: path.resolve(__dirname, './WebContent/zlux-hooks'),
+    to: path.resolve(OUTPUT_FOLDER, 'zlux-hooks'),
+},
+{
+    from: path.resolve(__dirname, './WebContent/css'),
+    to: path.resolve(OUTPUT_FOLDER, 'css'),
+},
+{
+    from: path.resolve(__dirname, './WebContent/img'),
+    to: path.resolve(OUTPUT_FOLDER, 'img'),
+},
+{
+    from: path.resolve(__dirname, './WebContent/index.html'),
+    to: path.resolve(OUTPUT_FOLDER),
+},
+{
+    from: path.resolve(__dirname, './WebContent/favicon.ico'),
+    to: path.resolve(OUTPUT_FOLDER),
+},
+]);
+
+const cleanTask = new CleanWebpackPlugin();
 
 module.exports = {
     devtool: debug ? 'source-map' : false,
@@ -47,7 +74,7 @@ module.exports = {
         path: path.join(__dirname, OUTPUT_FOLDER),
         filename: 'app.min.js',
     },
-    plugins: debug ? [] : [
+    plugins: debug ? [cleanTask, copyTask] : [cleanTask,
         new webpack.DefinePlugin({
             'process.env.REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD': true,
             'process.env.NODE_ENV': JSON.stringify(REACT_APP_ENVIRONMENT),
@@ -61,5 +88,10 @@ module.exports = {
                 },
             },
         }),
+        new CompressionPlugin({
+            threshold: 100000,
+            minRatio: 0.8,
+        }),
+        copyTask,
     ],
 };


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

**Webpack enhancements**
1) **COPY** - Moved copy static asses portion tied to 'dist' folder to webpack using copy-webpack-plugin
2) **COMPRESS** Added compression app.min.gz is one of the artifact produced here
3) **CLEAN** now folder is cleared and rebuild - using clean webpack plugin
4) Due to 1 & 3 - OUTPUT_FOLDER is truely configurable now, 
                            it helped remove npm run copy-static and npm run clean from npm 

Simplified, `npm run prod` & `npm run build`

**Logger Enhancement**
- retained redux dev tool extension logger its conditional on  on redux dev tool extension
- introduced new local storage flag to enable all redux activity on console log - it retains across windows refresh and even tab, as it uses local storage
