### PR TITLE
Keyring packaging fix

### DIFF
--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -58,8 +58,6 @@ mkdir -p "${PAX_WORKSPACE_DIR}/content/server"
 cp -r node_modules/explorer-ui-server/. "${PAX_WORKSPACE_DIR}/content/server"
 cd "${PAX_WORKSPACE_DIR}/content/server"
 npm install --only=production
-npm run prebuild
-npm install keyring_js
 
 cd "${ROOT_DIR}"
 

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -58,6 +58,9 @@ mkdir -p "${PAX_WORKSPACE_DIR}/content/server"
 cp -r node_modules/explorer-ui-server/. "${PAX_WORKSPACE_DIR}/content/server"
 cd "${PAX_WORKSPACE_DIR}/content/server"
 npm install --only=production
+npm run prebuild
+npm install keyring_js
+
 cd "${ROOT_DIR}"
 
 # copy explorer-jes to target folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -6436,6 +6436,15 @@
         "path-exists": "^3.0.0"
       }
     },
+    "keyring_js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keyring_js/-/keyring_js-1.0.1.tgz",
+      "integrity": "sha512-A5vMeGoSHnFuveee7OjyNFJd9Mo+yZs4weLIhegCvBu/3OjgFUNmeWUFbM4NwX/FBz3/lGX4uB8E/jpgjd8VwA==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.2.1"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lodash/-/lodash-4.17.15.tgz",
@@ -7539,6 +7548,12 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
+      "optional": true
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "peerDependencies": {
-    "explorer-ui-server": "0.2.12"
+    "explorer-ui-server": "0.2.13"
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",

--- a/scripts/explorer-jes-start.sh
+++ b/scripts/explorer-jes-start.sh
@@ -39,4 +39,7 @@ _BPX_JOBNAME=${JOB_NAME} $NODE_BIN $SERVER_DIR/src/index.js \
 	--key  ${KEYSTORE_KEY} \
 	--cert ${KEYSTORE_CERTIFICATE} \
 	--csp ${ZOWE_EXPLORER_FRAME_ANCESTORS} \
+	--keyring $KEYRING_NAME \
+	--keyring-owner $KEYRING_OWNER \
+	--keyring-label $KEY_ALIAS \
 	-v &


### PR DESCRIPTION
This PR addresses Issue:
https://github.com/zowe/explorer-ui-server/issues/35

Properly packaging keyring_js to avoid node-gyp issue, by including pre-build version

## PR Type
- [X ] Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.