### PR TITLE
resize tests should not consider other elements of the webpage to calculate the change in height of specified component. when size of windows changes

### DIFF
--- a/tests/FVTTests/homeView/testHomeView.ts
+++ b/tests/FVTTests/homeView/testHomeView.ts
@@ -438,29 +438,39 @@ describe('JES explorer function verification tests', function () {
             afterEach(async () => {
                 await driver.manage().window().setRect({ width: 1600, height: 800 });
             });
-            const browserHeaderHeight = 74;
-            const jobTreeTitleHeight = 52;
-            const appBarHeight = 32;
+            beforeEach(async () => {
+                await driver.manage().window().setRect({ width: 1600, height: 300 });
+            });
+            
+            var initialWindowHeight = 300;
+
             it('Should handle resizing of tree card component (tree-text-content)', async () => {
+                const treeTextContext = await driver.findElement(By.id('tree-text-content'));
+                const treeTextContextHeight = await treeTextContext.getCssValue('height');
+                const treeTextContextHeightInt = parseInt(treeTextContextHeight.substr(0, treeTextContextHeight.length - 2), 10);
                 expect(await testWindowHeightChangeForcesComponentHeightChange(
-                    driver, 'tree-text-content', browserHeaderHeight + jobTreeTitleHeight)).to.be.true;
+                    driver, 'tree-text-content', initialWindowHeight - treeTextContextHeightInt)).to.be.true;
             });
             it('Should handle resizing just the tree (full-height-tree)', async () => {
-                const filterCardHeight = 48;
+                const fullHeightTree = await driver.findElement(By.id('full-height-tree'));
+                const fullHeightTreeHeight = await fullHeightTree.getCssValue('height');
+                const fullHeightTreeHeightInt = parseInt(fullHeightTreeHeight.substr(0, fullHeightTreeHeight.length - 2), 10);
                 expect(await testWindowHeightChangeForcesComponentHeightChange(
-                    driver, 'full-height-tree', browserHeaderHeight + jobTreeTitleHeight + filterCardHeight)).to.be.true;
+                    driver, 'full-height-tree', initialWindowHeight - fullHeightTreeHeightInt)).to.be.true;
             });
             it('Should handle resizing of editor card component (content-viewer)', async () => {
+                const contentViewer = await driver.findElement(By.id('content-viewer'));
+                const contentViewerHeight = await contentViewer.getCssValue('height');
+                const contentViewerHeightInt = parseInt(contentViewerHeight.substr(0, contentViewerHeight.length - 2), 10);
                 expect(await testWindowHeightChangeForcesComponentHeightChange(
-                    driver, 'content-viewer', browserHeaderHeight+appBarHeight)).to.be.true;
+                    driver, 'content-viewer', initialWindowHeight - contentViewerHeightInt)).to.be.true;
             });
             it('Should handle resizing just the editor text area (embeddedEditor)', async () => {
-                const contentViewerHeader = await driver.findElement(By.id('content-viewer-header'));
-                const contentViewerHeaderHeight = await contentViewerHeader.getCssValue('height');
-                const contentViewerHeaderHeightInt = parseInt(contentViewerHeaderHeight.substr(0, contentViewerHeaderHeight.length - 2), 10);
-                const contentViewerHeaderPadding = 16;
+                const embeddedEditor = await driver.findElement(By.id('embeddedEditor'));
+                const embeddedEditorHeight = await embeddedEditor.getCssValue('height');
+                const embeddedEditorHeightInt = parseInt(embeddedEditorHeight.substr(0, embeddedEditorHeight.length - 2), 10);
                 expect(await testWindowHeightChangeForcesComponentHeightChange(
-                    driver, 'embeddedEditor', browserHeaderHeight + appBarHeight + contentViewerHeaderHeightInt + contentViewerHeaderPadding)).to.be.true;
+                    driver, 'embeddedEditor', initialWindowHeight - embeddedEditorHeightInt)).to.be.true;
             });
         });
     });


### PR DESCRIPTION
resize tests should not consider other elements of the webpage to calculate the change in height of a specified component. when the size of windows changes. Otherwise different users can get different results based on the browser or resolution used.


Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

## PR Type
- [ ] Bug fix
- [ ] Feature
- [ x] Other (Please indicate) This is test case fix

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.