### PR TITLE
adding the quotes around the variables in shell script to avoid not found sort of errors due to spaces in between

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -40,14 +40,14 @@ fi
 
 # start service
 _BPX_JOBNAME=${JOB_NAME} $NODE_BIN $SERVER_DIR/src/index.js \
-  --service ${EXPLORER_PLUGIN_NAME} \
-	--path ${EXPLORER_PLUGIN_BASEURI} \
-	--dir  ${EXPLORER_APP_DIR} \
-	--port ${JES_EXPLORER_UI_PORT} \
-	--key  ${KEYSTORE_KEY} \
-	--cert ${KEYSTORE_CERTIFICATE} \
-	--csp ${ZOWE_EXPLORER_FRAME_ANCESTORS} \
-	--keyring $KEYRING_NAME \
-	--keyring-owner $KEYRING_OWNER \
-	--keyring-label $KEY_ALIAS \
+  --service "${EXPLORER_PLUGIN_NAME}" \
+	--path "${EXPLORER_PLUGIN_BASEURI}" \
+	--dir  "${EXPLORER_APP_DIR}" \
+	--port "${JES_EXPLORER_UI_PORT}" \
+	--key  "${KEYSTORE_KEY}" \
+	--cert "${KEYSTORE_CERTIFICATE}" \
+	--csp "${ZOWE_EXPLORER_FRAME_ANCESTORS}" \
+	--keyring "${KEYRING_NAME}" \
+	--keyring-owner "${KEYRING_OWNER}" \
+	--keyring-label "${KEY_ALIAS}" \
 	-v &


### PR DESCRIPTION
adding the quotes around the variables in shell script to avoid not found sort of errors due to spaces in between

Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

## PR Type
- [ ] Bug fix
- [ ] Feature
- [x] Other (Please indicate)https://github.com/zowe/zlux/issues/677

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.