### PR TITLE
updating the explorer-fvt-utilities version to pick the new drivers for selenium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.14",
+      "version": "1.0.16",
       "license": "EPL-2.0",
       "dependencies": {
         "@material-ui/core": "^4.11.0",
@@ -62,7 +62,7 @@
         "eslint-plugin-node": "^5.1.1",
         "eslint-plugin-react": "^7.3.0",
         "expect": "^1.20.2",
-        "explorer-fvt-utilities": "1.0.7",
+        "explorer-fvt-utilities": "1.0.8",
         "file-loader": "^6.0.0",
         "html-webpack-plugin": "^4.4.1",
         "isomorphic-fetch": "^3.0.0",
@@ -489,12 +489,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha1-0mcp24UPoye3ysxVIiUhlEBCJvU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@testim/chrome-version": {
       "version": "1.0.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
       "integrity": "sha1-DNkVeF7EGQ8Io6asybYfw4+18ak=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+      "integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
     },
     "node_modules/@types/chai": {
       "version": "4.2.18",
@@ -521,6 +560,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -533,6 +579,16 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/keyv/-/keyv-3.1.2.tgz",
+      "integrity": "sha1-XZe7ZVJsILbghF9rDSreTyhgTuU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.4",
@@ -586,6 +642,16 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A=",
       "license": "MIT"
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.1",
@@ -682,9 +748,9 @@
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-0Q9p+fUi7vPPmOMK+2hKHh7JI68=",
+      "version": "2.9.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha1-xI5dVq/xREQJ45+hZLC01FUqe3o=",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -947,9 +1013,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/adm-zip/-/adm-zip-0.5.3.tgz",
-      "integrity": "sha1-9axrJQf0QY4mkcD+tvEwtLkNdkM=",
+      "version": "0.5.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha1-tlSdvqdB5AUDCfG7TUfEc5fOLE8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3090,6 +3156,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caching-transform": {
       "version": "3.0.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -3186,16 +3281,6 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/camelize/-/camelize-1.0.0.tgz",
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
       "license": "MIT"
-    },
-    "node_modules/capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/chai": {
       "version": "4.3.4",
@@ -3302,9 +3387,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "90.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chromedriver/-/chromedriver-90.0.1.tgz",
-      "integrity": "sha1-4yLZ/Kso2hJKJf1EaahoOwD2ngk=",
+      "version": "92.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chromedriver/-/chromedriver-92.0.1.tgz",
+      "integrity": "sha1-Pii34Mn7lNaTz3TVGvDCnVfxjco=",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3624,6 +3709,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
       }
     },
     "node_modules/clsx": {
@@ -4269,19 +4364,6 @@
       "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
       "license": "MIT"
     },
-    "node_modules/create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "capture-stack-trace": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-hash/-/create-hash-1.2.0.tgz",
@@ -4540,6 +4622,35 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-diff": {
       "version": "0.3.8",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/deep-diff/-/deep-diff-0.3.8.tgz",
@@ -4619,6 +4730,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-properties": {
@@ -4989,16 +5110,6 @@
       "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
@@ -5970,14 +6081,14 @@
       }
     },
     "node_modules/explorer-fvt-utilities": {
-      "version": "1.0.7",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/explorer-fvt-utilities/-/explorer-fvt-utilities-1.0.7.tgz",
-      "integrity": "sha1-MPE/8Lg5SjCXsW6eDZJ6KYtU1e4=",
+      "version": "1.0.8",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/explorer-fvt-utilities/-/explorer-fvt-utilities-1.0.8.tgz",
+      "integrity": "sha1-KWsq4XHlwX84xuikagPFL4i6ZbM=",
       "dev": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "chromedriver": "^90.0.1",
-        "geckodriver": "^1.19.1"
+        "chromedriver": "^92.0.1",
+        "geckodriver": "^2.0.3"
       }
     },
     "node_modules/express": {
@@ -6831,52 +6942,24 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "1.22.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/geckodriver/-/geckodriver-1.22.3.tgz",
-      "integrity": "sha1-MksxApROiSjme95hyhKa+sQX3s4=",
+      "version": "2.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/geckodriver/-/geckodriver-2.0.3.tgz",
+      "integrity": "sha1-bK/Asn/PhqG0RT+KFfqGEnm077k=",
       "dev": true,
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "adm-zip": "0.5.3",
+        "adm-zip": "0.5.5",
         "bluebird": "3.7.2",
-        "got": "5.6.0",
+        "got": "11.8.2",
         "https-proxy-agent": "5.0.0",
-        "tar": "6.0.2"
+        "tar": "6.1.2"
       },
       "bin": {
         "geckodriver": "bin/geckodriver"
-      }
-    },
-    "node_modules/geckodriver/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/geckodriver/node_modules/tar": {
-      "version": "6.0.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tar/-/tar-6.0.2.tgz",
-      "integrity": "sha1-XfF4E0aKYmT/FPdmiGxiK4SuLzk=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.0",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -7051,31 +7134,29 @@
       }
     },
     "node_modules/got": {
-      "version": "5.6.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/got/-/got-5.6.0.tgz",
-      "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
+      "version": "11.8.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/got/-/got-11.8.2.tgz",
+      "integrity": "sha1-ers5Weoowx81dvFXbB7/ziPzNZk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-plain-obj": "^1.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^2.0.0",
-        "unzip-response": "^1.0.0",
-        "url-parse-lax": "^1.0.0"
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -7514,6 +7595,13 @@
         "entities": "^2.0.0"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -7720,6 +7808,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-browserify": {
@@ -8446,16 +8548,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -8464,16 +8556,6 @@
       "dependencies": {
         "isobject": "^3.0.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8501,16 +8583,6 @@
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-set": {
       "version": "2.0.2",
@@ -8926,6 +8998,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -9087,6 +9166,16 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha1-TzqpjeJUgDyvzSiWc0EI2qNeQlQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/killable": {
@@ -9364,13 +9453,13 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+      "version": "2.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/lru-cache": {
@@ -9603,6 +9692,16 @@
       "version": "1.2.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10242,16 +10341,6 @@
         "vm-browserify": "^1.0.1"
       }
     },
-    "node_modules/node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -10273,6 +10362,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-all": {
@@ -11047,6 +11149,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-finally/-/p-finally-1.0.0.tgz",
@@ -11202,19 +11314,6 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/parse-passwd": {
@@ -11588,16 +11687,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/pretty-error": {
       "version": "2.1.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pretty-error/-/pretty-error-2.1.2.tgz",
@@ -11847,6 +11936,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ramda": {
       "version": "0.25.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ramda/-/ramda-0.25.0.tgz",
@@ -12066,20 +12168,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read-pkg": {
@@ -12497,6 +12585,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-alpn/-/resolve-alpn-1.2.0.tgz",
+      "integrity": "sha1-BYuwiI0c1NEkdOmktusXvdWt3EQ=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -12588,6 +12683,16 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
@@ -14006,9 +14111,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha1-0XJOm8wEuXexjVxXOzM6IgcimoM=",
+      "version": "6.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tar/-/tar-6.1.2.tgz",
+      "integrity": "sha1-HwRakKbrI1V6YDWV9BoWxX1HrcY=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -14420,16 +14525,6 @@
       "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/timed-out": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/timed-out/-/timed-out-2.0.0.tgz",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
@@ -14844,16 +14939,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "license": "MIT"
     },
-    "node_modules/unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/upath/-/upath-1.2.0.tgz",
@@ -14935,19 +15020,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/url/node_modules/punycode": {
@@ -17608,11 +17680,38 @@
         }
       }
     },
+    "@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha1-0mcp24UPoye3ysxVIiUhlEBCJvU=",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
     "@testim/chrome-version": {
       "version": "1.0.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
       "integrity": "sha1-DNkVeF7EGQ8Io6asybYfw4+18ak=",
       "dev": true
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+      "integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
+      "dev": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
     },
     "@types/chai": {
       "version": "4.2.18",
@@ -17636,6 +17735,12 @@
       "integrity": "sha1-PJ7pgPGhDWAhrmYyyj55yi7E+1A=",
       "dev": true
     },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -17646,6 +17751,15 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/keyv/-/keyv-3.1.2.tgz",
+      "integrity": "sha1-XZe7ZVJsILbghF9rDSreTyhgTuU=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.4",
@@ -17693,6 +17807,15 @@
       "integrity": "sha1-4aPLJ4339H8XtQgrGz2hcXC9RLE=",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/scheduler": {
@@ -17777,9 +17900,9 @@
       }
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-0Q9p+fUi7vPPmOMK+2hKHh7JI68=",
+      "version": "2.9.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha1-xI5dVq/xREQJ45+hZLC01FUqe3o=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -17999,9 +18122,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.5.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/adm-zip/-/adm-zip-0.5.3.tgz",
-      "integrity": "sha1-9axrJQf0QY4mkcD+tvEwtLkNdkM=",
+      "version": "0.5.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha1-tlSdvqdB5AUDCfG7TUfEc5fOLE8=",
       "dev": true
     },
     "agent-base": {
@@ -19772,6 +19895,27 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU=",
+      "dev": true
+    },
+    "cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      }
+    },
     "caching-transform": {
       "version": "3.0.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -19841,12 +19985,6 @@
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/camelize/-/camelize-1.0.0.tgz",
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
-    },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
-      "dev": true
     },
     "chai": {
       "version": "4.3.4",
@@ -19924,9 +20062,9 @@
       "integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
     },
     "chromedriver": {
-      "version": "90.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chromedriver/-/chromedriver-90.0.1.tgz",
-      "integrity": "sha1-4yLZ/Kso2hJKJf1EaahoOwD2ngk=",
+      "version": "92.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chromedriver/-/chromedriver-92.0.1.tgz",
+      "integrity": "sha1-Pii34Mn7lNaTz3TVGvDCnVfxjco=",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -20157,6 +20295,15 @@
             "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "clsx": {
@@ -20614,15 +20761,6 @@
         }
       }
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "^1.0.0"
-      }
-    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-hash/-/create-hash-1.2.0.tgz",
@@ -20809,6 +20947,23 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
+          "dev": true
+        }
+      }
+    },
     "deep-diff": {
       "version": "0.3.8",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/deep-diff/-/deep-diff-0.3.8.tgz",
@@ -20869,6 +21024,12 @@
       "requires": {
         "strip-bom": "^3.0.0"
       }
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -21146,15 +21307,6 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY=",
       "dev": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
     },
     "duplexify": {
       "version": "3.7.1",
@@ -21893,13 +22045,13 @@
       }
     },
     "explorer-fvt-utilities": {
-      "version": "1.0.7",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/explorer-fvt-utilities/-/explorer-fvt-utilities-1.0.7.tgz",
-      "integrity": "sha1-MPE/8Lg5SjCXsW6eDZJ6KYtU1e4=",
+      "version": "1.0.8",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/explorer-fvt-utilities/-/explorer-fvt-utilities-1.0.8.tgz",
+      "integrity": "sha1-KWsq4XHlwX84xuikagPFL4i6ZbM=",
       "dev": true,
       "requires": {
-        "chromedriver": "^90.0.1",
-        "geckodriver": "^1.19.1"
+        "chromedriver": "^92.0.1",
+        "geckodriver": "^2.0.3"
       }
     },
     "express": {
@@ -22540,38 +22692,16 @@
       "dev": true
     },
     "geckodriver": {
-      "version": "1.22.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/geckodriver/-/geckodriver-1.22.3.tgz",
-      "integrity": "sha1-MksxApROiSjme95hyhKa+sQX3s4=",
+      "version": "2.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/geckodriver/-/geckodriver-2.0.3.tgz",
+      "integrity": "sha1-bK/Asn/PhqG0RT+KFfqGEnm077k=",
       "dev": true,
       "requires": {
-        "adm-zip": "0.5.3",
+        "adm-zip": "0.5.5",
         "bluebird": "3.7.2",
-        "got": "5.6.0",
+        "got": "11.8.2",
         "https-proxy-agent": "5.0.0",
-        "tar": "6.0.2"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-          "dev": true
-        },
-        "tar": {
-          "version": "6.0.2",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tar/-/tar-6.0.2.tgz",
-          "integrity": "sha1-XfF4E0aKYmT/FPdmiGxiK4SuLzk=",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.0",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        }
+        "tar": "6.1.2"
       }
     },
     "get-caller-file": {
@@ -22687,27 +22817,22 @@
       }
     },
     "got": {
-      "version": "5.6.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/got/-/got-5.6.0.tgz",
-      "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
+      "version": "11.8.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/got/-/got-11.8.2.tgz",
+      "integrity": "sha1-ers5Weoowx81dvFXbB7/ziPzNZk=",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-plain-obj": "^1.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^2.0.0",
-        "unzip-response": "^1.0.0",
-        "url-parse-lax": "^1.0.0"
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -23023,6 +23148,12 @@
         "entities": "^2.0.0"
       }
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+      "dev": true
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -23188,6 +23319,16 @@
             "repeat-string": "^1.6.1"
           }
         }
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
+      "dev": true,
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "https-browserify": {
@@ -23677,12 +23818,6 @@
         "path-is-inside": "^1.0.2"
       }
     },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -23690,12 +23825,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
     },
     "is-regex": {
       "version": "1.1.3",
@@ -23711,12 +23840,6 @@
       "version": "1.1.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
       "dev": true
     },
     "is-set": {
@@ -24009,6 +24132,12 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -24145,6 +24274,15 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "keyv": {
+      "version": "4.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha1-TzqpjeJUgDyvzSiWc0EI2qNeQlQ=",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "killable": {
@@ -24343,9 +24481,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+      "version": "2.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
       "dev": true
     },
     "lru-cache": {
@@ -24515,6 +24653,12 @@
       "version": "1.2.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
       "dev": true
     },
     "mini-create-react-context": {
@@ -24977,12 +25121,6 @@
         "vm-browserify": "^1.0.1"
       }
     },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -25000,6 +25138,12 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "devOptional": true
+    },
+    "normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
+      "dev": true
     },
     "npm-run-all": {
       "version": "4.1.5",
@@ -25553,6 +25697,12 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-finally/-/p-finally-1.0.0.tgz",
@@ -25664,15 +25814,6 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -25944,12 +26085,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
     "pretty-error": {
       "version": "2.1.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pretty-error/-/pretty-error-2.1.2.tgz",
@@ -26134,6 +26269,12 @@
       "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "dev": true
     },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
+      "dev": true
+    },
     "ramda": {
       "version": "0.25.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ramda/-/ramda-0.25.0.tgz",
@@ -26298,16 +26439,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
       }
     },
     "read-pkg": {
@@ -26624,6 +26755,12 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-alpn": {
+      "version": "1.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-alpn/-/resolve-alpn-1.2.0.tgz",
+      "integrity": "sha1-BYuwiI0c1NEkdOmktusXvdWt3EQ=",
+      "dev": true
+    },
     "resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -26692,6 +26829,15 @@
       "version": "0.2.1",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -27769,9 +27915,9 @@
       "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I="
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha1-0XJOm8wEuXexjVxXOzM6IgcimoM=",
+      "version": "6.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tar/-/tar-6.1.2.tgz",
+      "integrity": "sha1-HwRakKbrI1V6YDWV9BoWxX1HrcY=",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -28061,12 +28207,6 @@
       "version": "1.1.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
-      "dev": true
-    },
-    "timed-out": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/timed-out/-/timed-out-2.0.0.tgz",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
       "dev": true
     },
     "timers-browserify": {
@@ -28368,12 +28508,6 @@
         }
       }
     },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
-    },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/upath/-/upath-1.2.0.tgz",
@@ -28444,15 +28578,6 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^1.0.1"
       }
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-react": "^7.3.0",
     "expect": "^1.20.2",
-    "explorer-fvt-utilities": "1.0.7",
+    "explorer-fvt-utilities": "1.0.8",
     "file-loader": "^6.0.0",
     "html-webpack-plugin": "^4.4.1",
     "isomorphic-fetch": "^3.0.0",


### PR DESCRIPTION
updating the explorer-fvt-utilities version to pick the new drivers for selenium

Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

## PR Type
- [ ] Bug fix
- [ ] Feature
- [x] Other (Please indicate)
updating the explorer-fvt-utilities version to pick the new drivers for selenium

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.