### PR TITLE
simplify destination configuration

### DIFF
--- a/pluginDefinition.prod.json
+++ b/pluginDefinition.prod.json
@@ -5,7 +5,7 @@
   "pluginType": "application",
   "webContent": {
     "framework": "iframe",
-    "destination": "https://${ZOWE_EXTERNAL_HOST}:${GATEWAY_PORT}/ui/v1/explorer-jes",
+    "destination": "/ui/v1/explorer-jes",
     "launchDefinition": {
       "pluginShortNameKey": "JES Explorer",
       "pluginShortNameDefault": "JES Explorer", 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

This PR addresses Issue that explorer-jes cannot be loaded in Kubernetes with NodePort service. The NodePort gateway port is 32554 which is not same as default gateway port 7554. Trying to load `https://${ZOWE_EXTERNAL_HOST}:${GATEWAY_PORT}` causes failure.

## PR Type
- [x] Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.