### PR TITLE
Skipping the test to list the jobs with OUTPUT status as zOSMF does not accept OUTPUT status filter

### DIFF
--- a/tests/FVTTests/filterParametersView/testFilterParameterView.ts
+++ b/tests/FVTTests/filterParametersView/testFilterParameterView.ts
@@ -183,7 +183,8 @@ describe('JES explorer home view with filter parameters in url query', function 
                 expect(await testJobStatusFilter(driver, expectedStatus)).to.be.true;
             });
 
-            it('Should handle fetching only OUTPUT jobs', async () => {
+            // zOSMF APIs only accepts Active or * as job status
+            it.skip('Should handle fetching only OUTPUT jobs', async () => {
                 const filters = { status: 'OUTPUT' };
                 const expectedFilter = { ...DEFAULT_SEARCH_FILTERS, ...filters };
                 const expectedStatus = ['ABEND', 'OUTPUT', 'CC', 'CANCELED', 'JCL', 'SYS', 'SEC'];


### PR DESCRIPTION
Signed-off-by: Adarshdeep Cheema adarshdeep.cheema@ibm.com

Skipping the test to list the jobs with OUTPUT status as zOSMF does not accept OUTPUT status filter

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

## PR Type
- [ ] Bug fix
- [ ] Feature
- [x] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.