### PR TITLE
Added app2args on launch: 'showDD' (opens specified data definition) 'expand' (expands job)

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -233,7 +233,7 @@ jobs:
           "${CUSTOM_FVT_ZOSMF_HOST:-${{ env.DEFAULT_FVT_ZOSMF_HOST }}}" \
           "${CUSTOM_FVT_ZOSMF_PORT:-${{ env.DEFAULT_FVT_ZOSMF_PORT }}}" \
           "${{ needs.build-ubuntu-amd64.outputs.IMAGE_NAME_FULL_REMOTE }}"
-          sleep 180
+          sleep 500
 
       - name: "[Test 2] Start integration test"
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -233,7 +233,7 @@ jobs:
           "${CUSTOM_FVT_ZOSMF_HOST:-${{ env.DEFAULT_FVT_ZOSMF_HOST }}}" \
           "${CUSTOM_FVT_ZOSMF_PORT:-${{ env.DEFAULT_FVT_ZOSMF_PORT }}}" \
           "${{ needs.build-ubuntu-amd64.outputs.IMAGE_NAME_FULL_REMOTE }}"
-          sleep 120
+          sleep 180
 
       - name: "[Test 2] Start integration test"
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -233,7 +233,7 @@ jobs:
           "${CUSTOM_FVT_ZOSMF_HOST:-${{ env.DEFAULT_FVT_ZOSMF_HOST }}}" \
           "${CUSTOM_FVT_ZOSMF_PORT:-${{ env.DEFAULT_FVT_ZOSMF_PORT }}}" \
           "${{ needs.build-ubuntu-amd64.outputs.IMAGE_NAME_FULL_REMOTE }}"
-          sleep 500
+          sleep 120
 
       - name: "[Test 2] Start integration test"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to the JES-Explorer will be documented in this file.
 
-## <1.0.20>
+## <1.0.21>
 
 ### New features and enhancements
 - Added app2app arguments: 'expand' - boolean that says to expand the job. In a list of jobs, this expands the first result. 'showDD' - string that will auto-open any dataset definition with this name, when expanding job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the JES-Explorer will be documented in this file.
 
 ## <1.0.20>
 
+### New features and enhancements
+- Added app2app arguments: 'expand' - boolean that says to expand the job. In a list of jobs, this expands the first result. 'showDD' - string that will auto-open any dataset definition with this name, when expanding job.
+
+## <1.0.20>
+
 ### Bug fixes
 - Fixed a bug where using app2app params at launch would not use desired data
 

--- a/WebContent/js/components/JobFile.js
+++ b/WebContent/js/components/JobFile.js
@@ -31,6 +31,15 @@ class JobFile extends React.Component {
             menuShortCuts: true,
             menuVisible: false,
         };
+
+        this.checkForShowDD();
+    }
+
+    checkForShowDD() {
+        const { file, showDD } = this.props;
+        if (file && file.label && file.label == showDD) {
+            this.openFile();
+        }
     }
 
     isFileOpen() {
@@ -171,7 +180,7 @@ JobFile.propTypes = {
 function mapStateToProps(state) {
     const contentRoot = state.get('content');
     return {
-        content: contentRoot.get('content'),
+        content: contentRoot.get('content')
     };
 }
 

--- a/WebContent/js/components/JobFile.js
+++ b/WebContent/js/components/JobFile.js
@@ -37,7 +37,7 @@ class JobFile extends React.Component {
 
     checkForShowDD() {
         const { file, showDD } = this.props;
-        if (file && file.label && file.label == showDD) {
+        if (file && file.label && file.label === showDD) {
             this.openFile();
         }
     }
@@ -169,6 +169,7 @@ class JobFile extends React.Component {
 
 JobFile.propTypes = {
     job: PropTypes.instanceOf(Map).isRequired,
+    showDD: PropTypes.string,
     content: PropTypes.instanceOf(List),
     file: PropTypes.shape({
         label: PropTypes.string.isRequired,
@@ -180,7 +181,7 @@ JobFile.propTypes = {
 function mapStateToProps(state) {
     const contentRoot = state.get('content');
     return {
-        content: contentRoot.get('content')
+        content: contentRoot.get('content'),
     };
 }
 

--- a/WebContent/js/components/JobInstance.js
+++ b/WebContent/js/components/JobInstance.js
@@ -40,7 +40,7 @@ class JobInstance extends React.Component {
 
     checkForExpand() {
         const { expand, pos } = this.props;
-        if (typeof (expand) == "boolean" && expand && pos == 0) {
+        if (typeof (expand) === 'boolean' && expand && pos === 0) {
             this.handleJobToggle();
         }
     }
@@ -328,6 +328,7 @@ JobInstance.propTypes = {
     dispatch: PropTypes.func.isRequired,
     showDD: PropTypes.string,
     expand: PropTypes.bool,
+    pos: PropTypes.number,
     job: PropTypes.instanceOf(Map).isRequired,
     jobs: PropTypes.instanceOf(List).isRequired,
     content: PropTypes.instanceOf(List),
@@ -340,7 +341,7 @@ function mapStateToProps(state) {
     return {
         content: contentRoot.get('content'),
         jobs: jobs.get('jobs'),
-        showDD: filtersRoot.get('showDD')
+        showDD: filtersRoot.get('showDD'),
     };
 }
 

--- a/WebContent/js/components/JobInstance.js
+++ b/WebContent/js/components/JobInstance.js
@@ -34,6 +34,15 @@ class JobInstance extends React.Component {
         };
 
         this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.checkForExpand = this.checkForExpand.bind(this);
+        setTimeout ( this.checkForExpand, 1500 ); // Give time for UI code to render before toggling expand
+    }
+
+    checkForExpand() {
+        const { expand, pos } = this.props;
+        if (typeof(expand) == "boolean" && expand && pos == 0) {
+            this.handleJobToggle();
+        }
     }
 
     handleSingleClick(e) {
@@ -218,10 +227,10 @@ class JobInstance extends React.Component {
     }
 
     renderJobFiles() {
-        const { job, dispatch } = this.props;
+        const { job, dispatch, showDD } = this.props;
         const files = job.get('files');
         return files.map(file => {
-            return (<JobFile key={file.id} job={job} dispatch={dispatch} file={file} />);
+            return (<JobFile key={file.id} job={job} showDD={showDD} dispatch={dispatch} file={file} />);
         });
     }
 
@@ -317,6 +326,7 @@ class JobInstance extends React.Component {
 
 JobInstance.propTypes = {
     dispatch: PropTypes.func.isRequired,
+    showDD: PropTypes.string,
     job: PropTypes.instanceOf(Map).isRequired,
     jobs: PropTypes.instanceOf(List).isRequired,
     content: PropTypes.instanceOf(List),
@@ -324,10 +334,12 @@ JobInstance.propTypes = {
 
 function mapStateToProps(state) {
     const contentRoot = state.get('content');
+    const filtersRoot = state.get('filters');
     const jobs = state.get('jobNodes');
     return {
         content: contentRoot.get('content'),
         jobs: jobs.get('jobs'),
+        showDD: filtersRoot.get('showDD')
     };
 }
 

--- a/WebContent/js/components/JobInstance.js
+++ b/WebContent/js/components/JobInstance.js
@@ -35,12 +35,12 @@ class JobInstance extends React.Component {
 
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.checkForExpand = this.checkForExpand.bind(this);
-        setTimeout ( this.checkForExpand, 1500 ); // Give time for UI code to render before toggling expand
+        setTimeout(this.checkForExpand, 1500); // Give time for UI code to render before toggling expand
     }
 
     checkForExpand() {
         const { expand, pos } = this.props;
-        if (typeof(expand) == "boolean" && expand && pos == 0) {
+        if (typeof (expand) == "boolean" && expand && pos == 0) {
             this.handleJobToggle();
         }
     }
@@ -327,6 +327,7 @@ class JobInstance extends React.Component {
 JobInstance.propTypes = {
     dispatch: PropTypes.func.isRequired,
     showDD: PropTypes.string,
+    expand: PropTypes.bool,
     job: PropTypes.instanceOf(Map).isRequired,
     jobs: PropTypes.instanceOf(List).isRequired,
     content: PropTypes.instanceOf(List),

--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -111,7 +111,7 @@ export class Filters extends React.Component {
             if (Object.keys(urlQueryParams).length > 0) {
                 const queryFilters = {};
                 Object.keys(urlQueryParams).forEach(filter => {
-                    if (['owner', 'prefix', 'jobId', 'status'].indexOf(filter) > -1) {
+                    if (['owner', 'prefix', 'jobId', 'status', 'expand', 'showDD'].indexOf(filter) > -1) {
                         queryFilters[filter] = urlQueryParams[filter].toUpperCase();
                     }
                 });
@@ -144,9 +144,11 @@ export class Filters extends React.Component {
 
     dispatchApp2AppData(messageData) {
         const { dispatch } = this.props;
-        if (messageData && messageData.owner && messageData.jobId) {
-            dispatch(setFilters(messageData));
-            dispatch(fetchJobs(messageData));
+        if (messageData) {
+            if (messageData.owner && messageData.jobId) {
+                dispatch(setFilters(messageData));
+                dispatch(fetchJobs(messageData));
+            }
         }
     }
 

--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -145,10 +145,8 @@ export class Filters extends React.Component {
     dispatchApp2AppData(messageData) {
         const { dispatch } = this.props;
         if (messageData) {
-            if (messageData.owner && messageData.jobId) {
-                dispatch(setFilters(messageData));
-                dispatch(fetchJobs(messageData));
-            }
+            dispatch(setFilters(messageData));
+            dispatch(fetchJobs(messageData));
         }
     }
 

--- a/WebContent/js/containers/JobTree.js
+++ b/WebContent/js/containers/JobTree.js
@@ -65,11 +65,11 @@ class JobNodeTree extends React.Component {
     };
 
     renderJobs() {
-        const { jobs, isFetching, dispatch } = this.props;
+        const { jobs, isFetching, dispatch, expand } = this.props;
         if (jobs && jobs.size >= 1) {
             return jobs.map((job, index) => {
                 return (
-                    <JobInstance key={job.get('label')} job={job} dispatch={dispatch} pos={index} size={jobs.size} />
+                    <JobInstance key={job.get('label')} expand={expand} job={job} dispatch={dispatch} pos={index} size={jobs.size} />
                 );
             });
         } else if (!isFetching) {
@@ -118,6 +118,7 @@ JobNodeTree.propTypes = {
     owner: PropTypes.string,
     jobId: PropTypes.string,
     status: PropTypes.string,
+    expand: PropTypes.bool,
     dispatch: PropTypes.func.isRequired,
     isFetching: PropTypes.bool.isRequired,
     jobs: PropTypes.instanceOf(List),
@@ -131,8 +132,9 @@ function mapStateToProps(state) {
         owner: filtersRoot.get('owner'),
         jobId: filtersRoot.get('jobId'),
         status: filtersRoot.get('status'),
+        expand: filtersRoot.get('expand'),
         isFetching: jobNodesRoot.get('isFetching'),
-        jobs: jobNodesRoot.get('jobs'),
+        jobs: jobNodesRoot.get('jobs')
     };
 }
 

--- a/WebContent/js/containers/JobTree.js
+++ b/WebContent/js/containers/JobTree.js
@@ -134,7 +134,7 @@ function mapStateToProps(state) {
         status: filtersRoot.get('status'),
         expand: filtersRoot.get('expand'),
         isFetching: jobNodesRoot.get('isFetching'),
-        jobs: jobNodesRoot.get('jobs')
+        jobs: jobNodesRoot.get('jobs'),
     };
 }
 

--- a/WebContent/js/reducers/filters.js
+++ b/WebContent/js/reducers/filters.js
@@ -18,6 +18,8 @@ const FilterRecord = Record({
     owner: '',
     status: '',
     jobId: '*',
+    expand: false,
+    showDD: '',
     isToggled: false,
 });
 

--- a/tests/UnitTests/testResources/reducers/filters.js
+++ b/tests/UnitTests/testResources/reducers/filters.js
@@ -18,6 +18,8 @@ export const BASE_FILTER_RECORD =
         owner: '',
         status: '',
         jobId: '*',
+        expand: false,
+        showDD: '',
         isToggled: false,
     });
 
@@ -27,6 +29,8 @@ export const USER_SET_FILTER_RECORD =
         owner: DEFAULT_USER,
         status: '',
         jobId: '*',
+        expand: false,
+        showDD: '',
         isToggled: true,
     });
 
@@ -45,6 +49,8 @@ export const TOGGLED_FILTER_RECORD =
         owner: '',
         status: '',
         jobId: '*',
+        expand: false,
+        showDD: '',
         isToggled: true,
     });
 
@@ -54,6 +60,8 @@ export const PREFIXED_FILTER_RECORD =
         owner: '',
         status: '',
         jobId: '*',
+        expand: false,
+        showDD: '',
         isToggled: false,
     });
 
@@ -63,6 +71,8 @@ export const FULLY_SET_FILTER_RECORD =
         owner: DEFAULT_USER,
         status: 'ACTIVE',
         jobId: '*',
+        expand: false,
+        showDD: '',
         isToggled: true,
     });
 
@@ -72,6 +82,8 @@ export const SPECIAL_CHARS_FILTER_RECORD =
         owner: "!@£$%^&*&^%$£@'test'",
         status: 'ACTIVE',
         jobId: '*',
+        expand: false,
+        showDD: 'TEST.JOBLOG',
         isToggled: true,
     });
 


### PR DESCRIPTION
Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>

Description: It would be nice if you could pass a parameter that makes the JES Explorer to show the job output straight away.

Today it just shows the job, and I must click on the job to expand the list of DDs, and then select a DD.

It would be nice if I could send something like:

   “jobId”: “JOB03462”
   “prefix”: “IZPJVS9M”
   “expand”: “true”
   “showDD”: “ADBMSGS”

to make the JES Explorer expand the list of DDs and show DD JESMSGLG from the first job in the list.

Or:

   “prefix”: “_ssid_MSTR”
   “expand”: “true”
   “showDD”: “JESMSGLG”
   “scrollToBottom”: “true”

![image](https://user-images.githubusercontent.com/20528015/150863407-f5a1e81f-9864-45f6-9100-a836772137b2.png)


## PR Type
- [ ] Bug fix
- [x] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [x] Relevant Test cases have been added (Unit and or FVT)
- [x] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.

How to Test?

Use Sample Angular App to launch JES Explorer with args. i.e.

{ "owner":"*", "jobId": "J0103626", "prefix": "ZWE*", "expand": true }

org.zowe.explorer-jes
