### PR TITLE
Allow all filter criteria via app2app

### DIFF
--- a/WebContent/js/containers/Filters.js
+++ b/WebContent/js/containers/Filters.js
@@ -143,7 +143,7 @@ export class Filters extends React.Component {
 
     dispatchApp2AppData(messageData) {
         const { dispatch } = this.props;
-        if (messageData && messageData.owner && messageData.jobId) {
+        if (messageData) {
             dispatch(setFilters(messageData));
             dispatch(fetchJobs(messageData));
         }


### PR DESCRIPTION
The JES Explorer only supports the single combination “owner” and “jobId”, see https://github.com/zowe/explorer-jes/blob/master/WebContent/js/containers/Filters.js#L102

We want to be able to pass other (any?) combinations of search criteria. Any reason why it is restricted to this exact combination?

Replacement for https://github.com/zowe/explorer-jes/pull/319

For our scenarios we generally have jobname (a.k.a prefix)  + jobid (see screenshot-1)

...but we’re thinking about other scenarios where we’d only have the jobname (a.k.a. the prefix): we want to show the Db2 MSTR output, so we only know the jobname: “_ssid_MSTR”

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

## PR Type
- [X] Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error - it doesnt like my line endings?
- - [ ] error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
- [X] PR from forked repo? Ensure Allow edits by maintaners is set.