### PR TITLE
Adding trivial schema to work with configmgr

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,6 +16,8 @@ build:
   branch: "{{build.branch}}"
   number: "{{build.number}}"
   commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
+  timestamp: {{build.timestamp}}
 appfwPlugins:
 - path: "."
+schemas:
+  configs: "schemas/trivial-schema.json"

--- a/schemas/trivial-schema.json
+++ b/schemas/trivial-schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/v2/explorer-jes",
+  "allOf": [
+    { "$ref": "https://zowe.org/schemas/v2/server-base" },
+    {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "explorer-jes": {
+              "$ref": "https://zowe.org/schemas/v2/server-base#zoweComponent"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR relates to issues: https://github.com/zowe/zowe-install-packaging/issues/2662 and https://github.com/zowe/zowe-install-packaging/issues/2879

## PR Type
- [x] Feature

It doesn't do very much. Basically, I'm adding a trivial schema that just says "some config could be here" (if there's config for explorers, we can certainly detail them! Please do!)
And then secondly, with the manifest schema, we noted that "timestamp" was meant to be a unix timestamp, so I'm removing the quotes so it can be treated as a number.