### PR TITLE
Fix endpoint for v3 zosmf route

### DIFF
--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -21,10 +21,11 @@ export function whichServer() {
 }
 
 // zosmf/
-const ZOSMF_PREFIX_LENGTH=6;
+const ZOSMF_PREFIX_LENGTH = 6;
 
 export function atlasFetch(endpoint, content) {
-  // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-  endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
-  return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${endpoint}`, content);
+    // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
+    endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+
+    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${endpoint}`, content);
 }

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -25,7 +25,7 @@ const ZOSMF_PREFIX_LENGTH = 6;
 
 export function atlasFetch(endpoint, content) {
     // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-    let trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+    const trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
 
     return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${trimmedEndpoint}`, content);
 }

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -20,6 +20,11 @@ export function whichServer() {
     return server;
 }
 
+// zosmf/
+const ZOSMF_PREFIX_LENGTH=6;
+
 export function atlasFetch(endpoint, content) {
-    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${endpoint}`, content);
+  // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
+  endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+  return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${endpoint}`, content);
 }

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -25,7 +25,7 @@ const ZOSMF_PREFIX_LENGTH = 6;
 
 export function atlasFetch(endpoint, content) {
     // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-    endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+    let trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
 
-    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${endpoint}`, content);
+    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/${trimmedEndpoint}`, content);
 }


### PR DESCRIPTION
In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL.
All URLs to zosmf in explorers are in form of 'zosmf/rest...' and are prefixed with APIML route in a single function.
So in this function, a substring operation is performed.