### PR TITLE
Adding permissions block for publishing releases

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,11 @@
 name: Build and Test Workflow
+
+permissions:
+  id-token: write
+  issues: write
+  pull-requests: write
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
The explorers cannot be published without an update to the publish workflow.
This change happened in other repos earlier this year but it appears at least for v2 explorers this was missed.
You can see that this PR just replicates the same code seen in other repositories to allow releases to proceed:

https://github.com/zowe/zowe-install-packaging/blob/b0007f35e579857be035ba6748023200d94c13f7/.github/workflows/build-packaging.yml#L3